### PR TITLE
Fix logger setup FileNotFoundError in fresh directories

### DIFF
--- a/.rapid/bug-init/bug-research.md
+++ b/.rapid/bug-init/bug-research.md
@@ -1,0 +1,132 @@
+# Bug Research: CLI Init Fails When .rapid/initialization.log Doesn't Pre-exist
+
+## Summary
+
+The CLI `init` command fails when the `.rapid/initialization.log` file doesn't pre-exist because the logger setup attempts to create a FileHandler for the log file before the `.rapid` directory structure is created.
+
+## Root Cause Analysis
+
+### The Bug Location
+
+The bug occurs in `src/rapid_tui/utils/file_operations.py` in the `TemplateManager._setup_logger()` method:
+
+```python
+def _setup_logger(self) -> logging.Logger:
+    """Configure logging for file operations."""
+    logger = logging.getLogger(__name__)
+    if not logger.handlers:
+        handler = logging.FileHandler(
+            self.project_root / ".rapid" / "initialization.log",  # ← BUG: Directory may not exist
+            mode='a'
+        )
+        formatter = logging.Formatter(
+            '%(asctime)s - %(levelname)s - %(message)s'
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+    return logger
+```
+
+**Lines: 42-44** - The FileHandler attempts to create/open `.rapid/initialization.log` but the `.rapid` directory may not exist yet.
+
+### Call Flow Analysis
+
+1. **CLI Init Command** (`src/rapid_tui/cli/commands/init.py:108`)
+   - Creates `InitializationService(project_path, dry_run=dry_run, force=force)`
+
+2. **InitializationService Constructor** (`src/rapid_tui/services/initialization.py:17-29`)
+   - Calls `service.initialize()` method
+
+3. **Service Initialize Method** (`src/rapid_tui/services/initialization.py:58-61`)
+   - Creates `TemplateManager(project_root=self.project_path, dry_run=self.dry_run)`
+
+4. **TemplateManager Constructor** (`src/rapid_tui/utils/file_operations.py:24-36`)
+   - Calls `self.logger = self._setup_logger()` **IMMEDIATELY**
+
+5. **Logger Setup** (`src/rapid_tui/utils/file_operations.py:38-52`)
+   - **FAILS HERE**: Attempts to create FileHandler for `.rapid/initialization.log`
+   - The `.rapid` directory doesn't exist yet!
+
+6. **Directory Creation** (`src/rapid_tui/utils/file_operations.py:82`)
+   - `self._ensure_rapid_directory()` is called much later in `initialize_project()`
+
+### Timing Issue
+
+The sequence of events that causes the bug:
+
+```
+TemplateManager.__init__()
+  ├── self._setup_logger()  ← Tries to create .rapid/initialization.log
+  │   └── FileHandler(.rapid/initialization.log) ← FAILS: .rapid/ doesn't exist
+  └── ... (other initialization)
+
+TemplateManager.initialize_project()  ← Called later
+  ├── self._ensure_rapid_directory()  ← Creates .rapid/ directory
+  └── ... (rest of initialization)
+```
+
+### Error Behavior
+
+When the `.rapid` directory doesn't exist:
+1. `logging.FileHandler()` attempts to open `.rapid/initialization.log`
+2. The parent directory `.rapid/` doesn't exist
+3. Python's `FileHandler` raises an exception (likely `FileNotFoundError` or `OSError`)
+4. This causes the entire initialization to fail before any meaningful work begins
+
+## Impact Assessment
+
+### User Experience Impact
+- **Complete initialization failure**: Users cannot run `rapid init` in fresh projects
+- **Confusing error messages**: The error about missing log file doesn't clearly indicate what went wrong
+- **Workaround required**: Users might need to manually create `.rapid/` directory first
+
+### Code Impact
+- **Constructor dependency**: TemplateManager constructor has an implicit dependency on `.rapid/` existing
+- **Initialization order**: Logger setup happens before directory structure creation
+- **Error handling**: No graceful fallback when log file cannot be created
+
+## Evidence from Code
+
+### Test Coverage Gap
+Looking at `tests/test_services_initialization.py`, the tests use `tmp_path` which creates temporary directories that likely don't have the `.rapid/` structure pre-existing. However, the tests may be passing due to:
+1. Test fixtures that create the directory structure
+2. Mocking that bypasses the actual file operations
+3. Different execution paths in test environment
+
+### Configuration Dependencies
+From `src/rapid_tui/utils/file_operations.py:18`, the TemplateManager imports configuration constants:
+```python
+from rapid_tui.config import (
+    get_assistant_config, get_agents_template_dir,
+    get_commands_template_dir, get_language_templates,
+    COPY_BUFFER_SIZE, MAX_RETRY_ATTEMPTS, RETRY_DELAY
+)
+```
+
+The logging setup is tightly coupled to the project structure expectations.
+
+## Reproduction Conditions
+
+The bug occurs when:
+1. Running `rapid init` in a fresh project directory
+2. The `.rapid/` directory doesn't exist
+3. The `.rapid/initialization.log` file doesn't exist
+4. The TemplateManager constructor is called
+
+## Related Code Locations
+
+- **Primary bug location**: `src/rapid_tui/utils/file_operations.py:42-44`
+- **Directory creation**: `src/rapid_tui/utils/file_operations.py:395-402` (`_ensure_rapid_directory`)
+- **Call sites**:
+  - `src/rapid_tui/cli/commands/init.py:108` (InitializationService creation)
+  - `src/rapid_tui/services/initialization.py:58` (TemplateManager creation)
+
+## Potential Fix Approaches
+
+1. **Defer logging setup**: Initialize logger only after directory structure exists
+2. **Conditional logging**: Use fallback logging (console or memory) until file logging is available
+3. **Directory-aware logging**: Check/create directory before setting up FileHandler
+4. **Lazy logging initialization**: Initialize file logging on first use rather than in constructor
+
+The fix should ensure that the `.rapid/` directory structure exists before attempting to create the log file handler.

--- a/src/rapid_tui/utils/file_operations.py
+++ b/src/rapid_tui/utils/file_operations.py
@@ -39,8 +39,13 @@ class TemplateManager:
         """Configure logging for file operations."""
         logger = logging.getLogger(__name__)
         if not logger.handlers:
+            # Ensure .rapid directory exists before creating log file
+            rapid_dir = self.project_root / ".rapid"
+            if not rapid_dir.exists():
+                rapid_dir.mkdir(parents=True, exist_ok=True)
+
             handler = logging.FileHandler(
-                self.project_root / ".rapid" / "initialization.log",
+                rapid_dir / "initialization.log",
                 mode='a'
             )
             formatter = logging.Formatter(

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -1,0 +1,65 @@
+"""Tests for file operations and TemplateManager."""
+
+import tempfile
+import pytest
+from pathlib import Path
+
+from rapid_tui.utils.file_operations import TemplateManager
+
+
+class TestTemplateManagerFreshDirectory:
+    """Test TemplateManager behavior in fresh directories."""
+
+    def test_template_manager_handles_fresh_directory(self):
+        """Test that TemplateManager can be instantiated in fresh directory without .rapid folder.
+
+        This is a regression test for the bug where logger setup failed when the .rapid
+        directory didn't exist during TemplateManager initialization.
+        """
+        import logging
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_path = Path(temp_dir)
+
+            # Verify .rapid doesn't exist initially
+            assert not (project_path / ".rapid").exists()
+
+            # Clear any existing logger handlers to ensure fresh setup
+            logger = logging.getLogger("rapid_tui.utils.file_operations")
+            for handler in logger.handlers[:]:
+                logger.removeHandler(handler)
+
+            # This should not raise FileNotFoundError
+            manager = TemplateManager(project_path)
+
+            # Verify .rapid directory was created for logging
+            assert (project_path / ".rapid").exists()
+            assert (project_path / ".rapid" / "initialization.log").exists()
+
+            # Verify manager is properly initialized
+            assert manager.project_root == project_path
+            assert manager.logger is not None
+
+    def test_template_manager_dry_run_fresh_directory(self):
+        """Test that TemplateManager dry run mode works in fresh directory."""
+        import logging
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            project_path = Path(temp_dir)
+
+            # Verify .rapid doesn't exist initially
+            assert not (project_path / ".rapid").exists()
+
+            # Clear any existing logger handlers to ensure fresh setup
+            logger = logging.getLogger("rapid_tui.utils.file_operations")
+            for handler in logger.handlers[:]:
+                logger.removeHandler(handler)
+
+            # Even in dry run mode, should create .rapid for logging
+            manager = TemplateManager(project_path, dry_run=True)
+
+            # Verify .rapid directory was created for logging even in dry run
+            # (logging needs to work regardless of dry_run mode)
+            assert (project_path / ".rapid").exists()
+            assert (project_path / ".rapid" / "initialization.log").exists()
+            assert manager.dry_run is True


### PR DESCRIPTION
The TemplateManager logger setup was failing when initializing in fresh
projects because it tried to create a FileHandler for .rapid/initialization.log
before the .rapid directory existed. This blocked users from running
`rapid init` in new projects.

Changes:
- Ensure .rapid directory exists before creating FileHandler in _setup_logger()
- Add regression tests for fresh directory initialization
- Test both normal and dry-run modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
